### PR TITLE
Take the current block predicate into account in reductions

### DIFF
--- a/src/native/NatBuilder.h
+++ b/src/native/NatBuilder.h
@@ -113,6 +113,7 @@ namespace native {
     BasicBlockVector &getAllBasicBlocksFor(llvm::BasicBlock *basicBlock);
 
     llvm::Value *createPTest(llvm::Value *vector, bool isRv_all);
+    llvm::Value *maskInactiveLanes(llvm::Value *const value, const BasicBlock* const block, bool invert);
 
     unsigned vectorWidth();
 


### PR DESCRIPTION
This branch makes `rv_any`, `rv_all`, and `rv_ballot` take the current block predicate into account, as explained in the following example:

```rust
for i in vectorize(0, 8) {
    if i < 4 {
        let mask = rv_ballot(true);
        // mask == 00001111b
    } else {
        let mask = rv_ballot(true);
        // mask == 11110000b
    }
}
```

This more or less matches the `__any`, `__all`, and `__ballot` intrinsics in CUDA.