### PR TITLE
Improved intrinsics support

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 # SET ( SLEEF_LIB_PATH "${CMAKE_BINARY_DIR}/rvlib.bc" CACHE FILEPATH "Wfv libary path" )
-SET ( RV_SLEEF_BC_DIR "${PROJ_ROOT_DIR}/vecmath/sleefsrc" )
+SET ( RV_SLEEF_BC_DIR "${CMAKE_BINARY_DIR}/lib" )
 # SET ( RV_LIB_MATH_DIR "${RV_LIB_DIR}/mathfun" )
 
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -D_DEBUG")

--- a/src/sleefLibrary.cpp
+++ b/src/sleefLibrary.cpp
@@ -110,13 +110,11 @@ namespace rv {
 
           {"llvm.sin.f32", "xsinf_avx2", 8},
           {"llvm.cos.f32", "xcosf_avx2", 8},
-          {"llvm.tan.f32", "xtanf_avx2", 8},
           {"llvm.log.f32", "xlogf_avx2", 8},
           {"llvm.exp.f32", "xexpf_avx2", 8},
           {"llvm.pow.f32", "xpowf_avx2", 8},
           {"llvm.sin.f64", "xsin_avx2", 4},
           {"llvm.cos.f64", "xcos_avx2", 4},
-          {"llvm.tan.f64", "xtan_avx2", 4},
           {"llvm.log.f64", "xlog_avx2", 4},
           {"llvm.exp.f64", "xexp_avx2", 4},
           {"llvm.pow.f64", "xpow_avx2", 4}
@@ -215,13 +213,11 @@ namespace rv {
 
           {"llvm.sin.f32", "xsinf_avx", 8},
           {"llvm.cos.f32", "xcosf_avx", 8},
-          {"llvm.tan.f32", "xtanf_avx", 8},
           {"llvm.log.f32", "xlogf_avx", 8},
           {"llvm.exp.f32", "xexpf_avx", 8},
           {"llvm.pow.f32", "xpowf_avx", 8},
           {"llvm.sin.f64", "xsin_avx", 4},
           {"llvm.cos.f64", "xcos_avx", 4},
-          {"llvm.tan.f64", "xtan_avx", 4},
           {"llvm.log.f64", "xlog_avx", 4},
           {"llvm.exp.f64", "xexp_avx", 4},
           {"llvm.pow.f64", "xpow_avx", 4}
@@ -313,13 +309,11 @@ namespace rv {
 
           {"llvm.sin.f32", "xsinf_sse", 4},
           {"llvm.cos.f32", "xcosf_sse", 4},
-          {"llvm.tan.f32", "xtanf_sse", 4},
           {"llvm.log.f32", "xlogf_sse", 4},
           {"llvm.exp.f32", "xexpf_sse", 4},
           {"llvm.pow.f32", "xpowf_sse", 4},
           {"llvm.sin.f64", "xsin_sse", 2},
           {"llvm.cos.f64", "xcos_sse", 2},
-          {"llvm.tan.f64", "xtan_sse", 2},
           {"llvm.log.f64", "xlog_sse", 2},
           {"llvm.exp.f64", "xexp_sse", 2},
           {"llvm.pow.f64", "xpow_sse", 2}

--- a/vecmath/CMakeLists.txt
+++ b/vecmath/CMakeLists.txt
@@ -14,38 +14,61 @@ SET ( SLEEF_BC_SSE_DP "${VECMATH_LIB_DIR}/sse_sleef_dp.bc" )
 
 SET ( SLEEF_BC_LIBS ${SLEEF_BC_AVX2_SP} ${SLEEF_BC_AVX_SP} ${SLEEF_BC_SSE_SP} ${SLEEF_BC_AVX2_DP} ${SLEEF_BC_AVX_DP} ${SLEEF_BC_SSE_DP} )
 
-SET( RV_LIB_SLEEF_OUT_DIR "${CMAKE_BINARY_DIR}/lib" )
+SET ( RV_LIB_SLEEF_OUT_DIR ${VECMATH_LIB_DIR} )
 
-# build SLEEF bc libs
+SET ( RV_LIB_EXTRA_DIR "${PROJ_ROOT_DIR}/vecmath/extra")
+SET ( EXTRA_BC_AVX_SP  "${VECMATH_LIB_DIR}/avx_extra_sp.bc" )
+SET ( EXTRA_BC_SSE_SP  "${VECMATH_LIB_DIR}/sse_extra_sp.bc" )
+SET ( EXTRA_BC_AVX_DP  "${VECMATH_LIB_DIR}/avx_extra_dp.bc" )
+SET ( EXTRA_BC_SSE_DP  "${VECMATH_LIB_DIR}/sse_extra_dp.bc" )
+
+# build SLEEF & others bc libs
 IF (ENABLE_SLEEF AND IS_DIRECTORY ${RV_LIB_SLEEF_DIR})
   MESSAGE("-- SLEEF sources found: ${SLEEF_DIR}")
-  ADD_CUSTOM_TARGET ( libsleef_x64 DEPENDS ${SLEEF_BC_AVX2_SP} ${SLEEF_BC_AVX_SP} ${SLEEF_BC_SSE_SP} ${SLEEF_BC_AVX2_DP} ${SLEEF_BC_AVX_DP} ${SLEEF_BC_SSE_DP} )
+  ADD_CUSTOM_TARGET ( libsleef_x64 DEPENDS ${SLEEF_BC_LIBS} )
 
   SET( RVLIB_BUILD_OPTS -O3 )
+  # Sleef single precision
   ADD_CUSTOM_COMMAND (
-          OUTPUT ${SLEEF_BC_AVX2_SP}
-          COMMAND mkdir -p ${RV_LIB_SLEEF_OUT_DIR} && ${LLVM_TOOL_CLANG} ${RV_LIB_SLEEF_DIR}/sleefsimdsp.c -emit-llvm -c -Wall -Wno-unused-function ${RVLIB_BUILD_OPTS} -march=haswell -mavx2 -mfma -DENABLE_AVX2=ON -o ${SLEEF_BC_AVX2_SP}
+    OUTPUT ${SLEEF_BC_AVX2_SP}
+    COMMAND mkdir -p ${RV_LIB_SLEEF_OUT_DIR}
+    COMMAND ${LLVM_TOOL_CLANG} ${RV_LIB_SLEEF_DIR}/sleefsimdsp.c -emit-llvm -c -Wall -Wno-unused-function ${RVLIB_BUILD_OPTS} -march=haswell -mavx2 -mfma -DENABLE_AVX2=ON -o ${SLEEF_BC_AVX2_SP}
   )
   ADD_CUSTOM_COMMAND (
-          OUTPUT ${SLEEF_BC_AVX_SP}
-          COMMAND mkdir -p ${RV_LIB_SLEEF_OUT_DIR} && ${LLVM_TOOL_CLANG} ${RV_LIB_SLEEF_DIR}/sleefsimdsp.c -emit-llvm -c -Wall -Wno-unused-function ${RVLIB_BUILD_OPTS} -mavx -DENABLE_AVX=ON -o ${SLEEF_BC_AVX_SP}
+    OUTPUT ${SLEEF_BC_AVX_SP}
+    COMMAND mkdir -p ${RV_LIB_SLEEF_OUT_DIR}
+    COMMAND ${LLVM_TOOL_CLANG} ${RV_LIB_SLEEF_DIR}/sleefsimdsp.c -emit-llvm -c -Wall -Wno-unused-function ${RVLIB_BUILD_OPTS} -mavx -DENABLE_AVX=ON -o ${SLEEF_BC_AVX_SP}.tmp
+    COMMAND ${LLVM_TOOL_CLANG} ${RV_LIB_EXTRA_DIR}/extrasp.c -emit-llvm -c -Wall -Wno-unused-function ${RVLIB_BUILD_OPTS} -mavx -DENABLE_AVX=ON -o ${EXTRA_BC_AVX_SP}
+    COMMAND ${LLVM_TOOL_LINK} ${EXTRA_BC_AVX_SP} ${SLEEF_BC_AVX_SP}.tmp -o ${SLEEF_BC_AVX_SP}
   )
   ADD_CUSTOM_COMMAND (
-          OUTPUT ${SLEEF_BC_SSE_SP}
-          COMMAND mkdir -p ${RV_LIB_SLEEF_OUT_DIR} && ${LLVM_TOOL_CLANG} ${RV_LIB_SLEEF_DIR}/sleefsimdsp.c -emit-llvm -c -Wall -Wno-unused-function ${RVLIB_BUILD_OPTS} -m64 -msse4 -DENABLE_SSE2=ON -o ${SLEEF_BC_SSE_SP}
+    OUTPUT ${SLEEF_BC_SSE_SP}
+    COMMAND mkdir -p ${RV_LIB_SLEEF_OUT_DIR}
+    COMMAND ${LLVM_TOOL_CLANG} ${RV_LIB_SLEEF_DIR}/sleefsimdsp.c -emit-llvm -c -Wall -Wno-unused-function ${RVLIB_BUILD_OPTS} -m64 -msse4 -DENABLE_SSE2=ON -o ${SLEEF_BC_SSE_SP}.tmp
+    COMMAND ${LLVM_TOOL_CLANG} ${RV_LIB_EXTRA_DIR}/extrasp.c -emit-llvm -c -Wall -Wno-unused-function ${RVLIB_BUILD_OPTS} -m64 -msse4 -DENABLE_SSE2=ON -o ${EXTRA_BC_SSE_SP}
+    COMMAND ${LLVM_TOOL_LINK} ${EXTRA_BC_SSE_SP} ${SLEEF_BC_SSE_SP}.tmp -o ${SLEEF_BC_SSE_SP}
+  )
+  # Sleef double precision
+  ADD_CUSTOM_COMMAND (
+    OUTPUT ${SLEEF_BC_AVX2_DP}
+    COMMAND mkdir -p ${RV_LIB_SLEEF_OUT_DIR}
+    COMMAND ${LLVM_TOOL_CLANG} ${RV_LIB_SLEEF_DIR}/sleefsimddp.c -emit-llvm -c -Wall -Wno-unused-function ${RVLIB_BUILD_OPTS} -march=haswell -mavx2 -mfma -DENABLE_AVX2=ON -o ${SLEEF_BC_AVX2_DP}
   )
   ADD_CUSTOM_COMMAND (
-          OUTPUT ${SLEEF_BC_AVX2_DP}
-          COMMAND mkdir -p ${RV_LIB_SLEEF_OUT_DIR} && ${LLVM_TOOL_CLANG} ${RV_LIB_SLEEF_DIR}/sleefsimddp.c -emit-llvm -c -Wall -Wno-unused-function ${RVLIB_BUILD_OPTS} -march=haswell -mavx2 -mfma -DENABLE_AVX2=ON -o ${SLEEF_BC_AVX2_DP}
+    OUTPUT ${SLEEF_BC_AVX_DP}
+    COMMAND mkdir -p ${RV_LIB_SLEEF_OUT_DIR}
+    COMMAND ${LLVM_TOOL_CLANG} ${RV_LIB_SLEEF_DIR}/sleefsimddp.c -emit-llvm -c -Wall -Wno-unused-function ${RVLIB_BUILD_OPTS} -mavx -DENABLE_AVX=ON -o ${SLEEF_BC_AVX_DP}.tmp
+    COMMAND ${LLVM_TOOL_CLANG} ${RV_LIB_EXTRA_DIR}/extradp.c -emit-llvm -c -Wall -Wno-unused-function ${RVLIB_BUILD_OPTS} -mavx -DENABLE_AVX=ON -o ${EXTRA_BC_AVX_DP}
+    COMMAND ${LLVM_TOOL_LINK} ${EXTRA_BC_AVX_DP} ${SLEEF_BC_AVX_DP}.tmp -o ${SLEEF_BC_AVX_DP}
   )
   ADD_CUSTOM_COMMAND (
-          OUTPUT ${SLEEF_BC_AVX_DP}
-          COMMAND mkdir -p ${RV_LIB_SLEEF_OUT_DIR} && ${LLVM_TOOL_CLANG} ${RV_LIB_SLEEF_DIR}/sleefsimddp.c -emit-llvm -c -Wall -Wno-unused-function ${RVLIB_BUILD_OPTS} -mavx -DENABLE_AVX=ON -o ${SLEEF_BC_AVX_DP}
+    OUTPUT ${SLEEF_BC_SSE_DP}
+    COMMAND mkdir -p ${RV_LIB_SLEEF_OUT_DIR}
+    COMMAND ${LLVM_TOOL_CLANG} ${RV_LIB_SLEEF_DIR}/sleefsimddp.c -emit-llvm -c -Wall -Wno-unused-function ${RVLIB_BUILD_OPTS} -m64 -msse4 -DENABLE_SSE2=ON -o ${SLEEF_BC_SSE_DP}.tmp
+    COMMAND ${LLVM_TOOL_CLANG} ${RV_LIB_EXTRA_DIR}/extradp.c -emit-llvm -c -Wall -Wno-unused-function ${RVLIB_BUILD_OPTS} -m64 -msse4 -DENABLE_SSE2=ON -o ${EXTRA_BC_SSE_DP}
+    COMMAND ${LLVM_TOOL_LINK} ${EXTRA_BC_SSE_DP} ${SLEEF_BC_SSE_DP}.tmp -o ${SLEEF_BC_SSE_DP}
   )
-  ADD_CUSTOM_COMMAND (
-          OUTPUT ${SLEEF_BC_SSE_DP}
-          COMMAND mkdir -p ${RV_LIB_SLEEF_OUT_DIR} && ${LLVM_TOOL_CLANG} ${RV_LIB_SLEEF_DIR}/sleefsimddp.c -emit-llvm -c -Wall -Wno-unused-function ${RVLIB_BUILD_OPTS} -m64 -msse4 -DENABLE_SSE2=ON -o ${SLEEF_BC_SSE_DP}
-  )
+
   ADD_DEPENDENCIES ( ${LIBRARY_NAME} libsleef_x64 )
 
   INSTALL ( FILES ${SLEEF_BC_LIBS} DESTINATION lib COMPONENT sleef )

--- a/vecmath/extra/extradp.c
+++ b/vecmath/extra/extradp.c
@@ -1,0 +1,39 @@
+#include <immintrin.h>
+#include <stdint.h>
+
+inline double as_double(int64_t x) {
+    union { int64_t i; double d; } u = { .i = x };
+    return u.d;
+}
+
+#ifdef ENABLE_AVX
+__m256d xfabs(__m256d x) {
+    return _mm256_and_pd(x, _mm256_set1_pd(as_double(0x7FFFFFFFFFFFFFFFll)));
+}
+__m256d xcopysign(__m256d x, __m256d y) {
+    __m256d s = _mm256_and_pd(y, _mm256_set1_pd(as_double(0x8000000000000000)));
+    return _mm256_or_pd(_mm256_and_pd(x, _mm256_set1_pd(as_double(0x7FFFFFFFFFFFFFFF))), s);
+}
+__m256d xfmin(__m256d x, __m256d y) {
+    return _mm256_blendv_pd(y, x, _mm256_cmp_pd(x, y, 1));
+}
+__m256d xfmax(__m256d x, __m256d y) {
+    return _mm256_blendv_pd(y, x, _mm256_cmp_pd(x, y, 6));
+}
+#endif
+
+#ifdef ENABLE_SSE41
+__m128d xfabs(__m128d x) {
+    return _mm_and_pd(x, _mm_set1_pd(as_double(0x7FFFFFFFFFFFFFFFll)));
+}
+__m128d xcopysign(__m128d x, __m128d y) {
+    __m128d s = _mm_and_pd(y, _mm_set1_pd(as_double(0x8000000000000000)));
+    return _mm_or_pd(_mm_and_pd(x, _mm_set1_pd(as_double(0x7FFFFFFFFFFFFFFF))), s);
+}
+__m128d xfmin(__m128d x, __m128d y) {
+    return _mm_blendv_pd(y, x, _mm_cmplt_pd(x, y));
+}
+__m128d xfmax(__m128d x, __m128d y) {
+    return _mm_blendv_pd(y, x, _mm_cmpnle_pd(x, y));
+}
+#endif

--- a/vecmath/extra/extrasp.c
+++ b/vecmath/extra/extrasp.c
@@ -1,0 +1,39 @@
+#include <immintrin.h>
+#include <stdint.h>
+
+inline float as_float(int x) {
+    union { int i; float f; } u = { .i = x };
+    return u.f;
+}
+
+#ifdef ENABLE_AVX
+__m256 xfabsf(__m256 x) {
+    return _mm256_and_ps(x, _mm256_set1_ps(as_float(0x7FFFFFFF)));
+}
+__m256 xcopysignf(__m256 x, __m256 y) {
+    __m256 s = _mm256_and_ps(y, _mm256_set1_ps(as_float(0x80000000)));
+    return _mm256_or_ps(_mm256_and_ps(x, _mm256_set1_ps(as_float(0x7FFFFFFF))), s);
+}
+__m256 xfminf(__m256 x, __m256 y) {
+    return _mm256_blendv_ps(y, x, _mm256_cmp_ps(x, y, 1));
+}
+__m256 xfmaxf(__m256 x, __m256 y) {
+    return _mm256_blendv_ps(y, x, _mm256_cmp_ps(x, y, 6));
+}
+#endif
+
+#ifdef ENABLE_SSE41
+__m128 xfabsf(__m128 x) {
+    return _mm_and_ps(x, _mm_set1_ps(as_float(0x7FFFFFFF)));
+}
+__m128 xcopysignf(__m128 x, __m128 y) {
+    __m128 s = _mm_and_ps(y, _mm_set1_ps(as_float(0x80000000)));
+    return _mm_or_ps(_mm_and_ps(x, _mm_set1_ps(as_float(0x7FFFFFFF))), s);
+}
+__m128 xfminf(__m128 x, __m128 y) {
+    return _mm_blendv_ps(y, x, _mm_cmplt_ps(x, y));
+}
+__m128 xfmaxf(__m128 x, __m128 y) {
+    return _mm_blendv_ps(y, x, _mm_cmpnle_ps(x, y));
+}
+#endif


### PR DESCRIPTION
This branch adds intrinsic support for `fabs`, `copysign`, `fmin` and `fmax`. The use of llvm intrinsics or C math library names is allowed, and both will trigger the selection of the right intrinsic function (i.e. one can use interchangeably `llvm.sin.f32` or `sinf`). This pull request also adds the basic CMake infrastructure to implement new intrinsics not present in SLEEF.