### PR TITLE
Accounting visited instructions with missing shapes

### DIFF
--- a/include/rv/analysis/VectorizationAnalysis.h
+++ b/include/rv/analysis/VectorizationAnalysis.h
@@ -12,6 +12,7 @@
 #include <string>
 #include <map>
 #include <queue>
+#include <unordered_set>
 
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
@@ -69,6 +70,7 @@ class VectorizationAnalysis {
 
   /// Next instructions to handle
   std::queue<const llvm::Instruction*> mWorklist;
+  std::unordered_set<const llvm::Instruction*> visitedMissingShapes;
 
   const llvm::DataLayout& layout;
   const llvm::LoopInfo& mLoopInfo; // Preserves LoopInfo

--- a/src/analysis/VectorizationAnalysis.cpp
+++ b/src/analysis/VectorizationAnalysis.cpp
@@ -372,7 +372,7 @@ bool VectorizationAnalysis::pushMissingOperands(const Instruction* I) {
     bool push = isa<Instruction>(op) && !getShape(*op).isDefined();
     if (push) {
       IF_DEBUG_VA { errs() << "\tmissing op shape " << *op << "!\n"; }
-      mWorklist.push(cast<Instruction>(op));
+      if (std::find(visitedMissingShapes.begin(), visitedMissingShapes.end(), cast<Instruction>(op)) == visitedMissingShapes.end()) mWorklist.push(cast<Instruction>(op));
     }
 
     return prevpushed || push;
@@ -400,6 +400,8 @@ void VectorizationAnalysis::compute(const Function& F) {
   while (!mWorklist.empty()) {
     const Instruction* I = mWorklist.front();
     mWorklist.pop();
+    
+    visitedMissingShapes.insert(I);
 
     if (vecInfo.isPinned(*I)) {
       continue;


### PR DESCRIPTION
Blindly pushing to the worklist can lead to an infinite growth.
This change assures, that "undefined shape" instructions are only visited once (until they are repushed as a user of a newly shape-computed instruction in 'addDependentValuesToWL').

Assuming you'd want an example of this happening, I'll prepare a gist of the IR. (Which has only 800-ish lines of IR-code, but doesn't stop even after 3 million mWorklist size)