### PR TITLE
fix: make rv_load/rv_store work with imprecise varying shapes

### DIFF
--- a/include/rv/LinkAllPasses.h
+++ b/include/rv/LinkAllPasses.h
@@ -28,6 +28,7 @@ void initializeLoopVectorizerPass(PassRegistry&);
 void initializeWFVPassPass(PassRegistry&);
 void initializeIRPolisherWrapperPass(PassRegistry&);
 void initializeCNSPass(PassRegistry&);
+void initializeLowerRVIntrinsicsPass(PassRegistry&);
 } // namespace llvm
 
 namespace {
@@ -45,6 +46,7 @@ struct RVForcePassLinking {
     rv::createIRPolisherWrapperPass();
     rv::createCNSPass();
     rv::createWFVPass();
+    rv::createLowerRVIntrinsicsPass();
   }
 } RVForcePassLinking; // Force link by creating a global definition.
 

--- a/include/rv/analysis/costModel.h
+++ b/include/rv/analysis/costModel.h
@@ -31,7 +31,7 @@ public:
   CostModel(PlatformInfo & _platInfo, Config & _config);
 
   // whether this is an vectorizable LLVM intrinsic
-  bool IsVectorizableIntrinsic(llvm::Function & Callee) const;
+  bool IsVectorizableFunction(llvm::Function & Callee) const;
 
   // pick a width for @inst
   size_t pickWidthForInstruction(const llvm::Instruction & inst, size_t maxWidth) const;

--- a/include/rv/analysis/costModel.h
+++ b/include/rv/analysis/costModel.h
@@ -8,6 +8,7 @@ namespace llvm {
   class Type;
   class BasicBlock;
   class TargetTransformInfo;
+  class Function;
 }
 
 namespace rv {
@@ -28,6 +29,9 @@ class CostModel {
 
 public:
   CostModel(PlatformInfo & _platInfo, Config & _config);
+
+  // whether this is an vectorizable LLVM intrinsic
+  bool IsVectorizableIntrinsic(llvm::Function & Callee) const;
 
   // pick a width for @inst
   size_t pickWidthForInstruction(const llvm::Instruction & inst, size_t maxWidth) const;

--- a/include/rv/passes.h
+++ b/include/rv/passes.h
@@ -25,6 +25,8 @@ namespace rv {
   // Controlled Node Splitting (Irreducible loop normalization)
   llvm::FunctionPass *createCNSPass();
 
+  // Controlled Node Splitting (Irreducible loop normalization)
+  llvm::FunctionPass *createLowerRVIntrinsicsPass();
 
   // add normalization passes required by RV (BEFORE)
   void addPreparatoryPasses(llvm::legacy::PassManagerBase & PM);
@@ -37,6 +39,9 @@ namespace rv {
 
   // add cleanup passes to run after RV (AFTER)
   void addCleanupPasses(llvm::legacy::PassManagerBase & PM);
+
+  // insert a pass that
+  void addLowerBuiltinsPass(llvm::legacy::PassManagerBase & PM);
 } // namespace rv
 
 

--- a/include/rv/rv.h
+++ b/include/rv/rv.h
@@ -102,8 +102,8 @@ private:
    // implement all rv_* intrinsics
    // this is necessary to make scalar functions with predicate intrinsics executable
    // the SIMS semantics of the function will change if @scalar func used any mask intrinsics
-  void lowerIntrinsics(llvm::Function & scalarFunc);
-  void lowerIntrinsics(llvm::Module & mod);
+  bool lowerIntrinsics(llvm::Function & scalarFunc);
+  bool lowerIntrinsics(llvm::Module & mod);
 }
 
 #endif // RV_RV_H

--- a/include/rv/transform/WFVPass.h
+++ b/include/rv/transform/WFVPass.h
@@ -48,7 +48,14 @@ class WFVPass : public llvm::ModulePass {
   bool enableDiagOutput; // WFV_DIAG
 
   std::vector<VectorMapping> wfvJobs;
+
+  /// collect all stray Vector Function ABI strings in the attributes of \p F.
   void collectJobs(llvm::Function & F);
+
+  /// check that \p wfvJob is a sane function mapping.
+  bool isSaneMapping(VectorMapping & wfvJob) const;
+
+  /// generate the Vector Function ABI variant encoded in \p wfvJob.
   void vectorizeFunction(VectorizerInterface & vectorizer, VectorMapping & wfvJob);
 public:
   static char ID;

--- a/include/rv/transform/lowerRVIntrinsics.h
+++ b/include/rv/transform/lowerRVIntrinsics.h
@@ -1,0 +1,28 @@
+//===- transform/lowerRVIntrinsics.h - lower intrinsics  ----------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+//
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/Pass.h"
+
+namespace rv {
+class LowerRVIntrinsics : public llvm::FunctionPass {
+public:
+  static char ID;
+  LowerRVIntrinsics() : llvm::FunctionPass(ID)
+  {}
+
+  bool runOnFunction(llvm::Function &F) override;
+
+  /// Register all analyses and transformation required.
+  void getAnalysisUsage(llvm::AnalysisUsage &AU) const override;
+};
+
+} // namespace rv

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -63,29 +63,30 @@ add_rv_library(RV
   transform/CNSPass.cpp
   transform/Linearizer.cpp
   transform/LoopVectorizer.cpp
+  transform/WFVPass.cpp
   transform/bosccTransform.cpp
-  transform/crtLowering.cpp
   transform/cns/BlockGraph.cpp
   transform/cns/CNS.cpp
   transform/cns/CNSScoring.cpp
   transform/cns/SplitTree.cpp
   transform/cns/llvmDomination.cpp
   transform/cns/llvmDuplication.cpp
+  transform/crtLowering.cpp
   transform/divLoopTrans.cpp
   transform/irPolisher.cpp
   transform/loopCloner.cpp
   transform/loopExitCanonicalizer.cpp
   transform/lowerDivergentSwitches.cpp
+  transform/lowerRVIntrinsics.cpp
   transform/maskExpander.cpp
   transform/memCopyElision.cpp
-  transform/redTools.cpp
   transform/redOpt.cpp
+  transform/redTools.cpp
   transform/remTransform.cpp
   transform/singleReturnTrans.cpp
+  transform/splitAllocas.cpp
   transform/srovTransform.cpp
   transform/structOpt.cpp
-  transform/splitAllocas.cpp
-  transform/WFVPass.cpp
   utils.cpp
   utils/rvLinking.cpp
   utils/rvTools.cpp

--- a/src/PlatformInfo.cpp
+++ b/src/PlatformInfo.cpp
@@ -19,6 +19,12 @@
 
 using namespace llvm;
 
+#if 0
+#define IF_DEBUG_PLAT if (true)
+#else
+#define IF_DEBUG_PLAT IF_DEBUG
+#endif
+
 namespace rv {
 
 static bool
@@ -123,6 +129,16 @@ PlatformInfo::getResolver(StringRef funcName,
                           const VectorShapeVec & argShapes,
                           int vectorWidth,
                           bool hasPredicate) const {
+  IF_DEBUG_PLAT {
+    errs() << "Resolver query:\n"
+           << "scaName:  " << funcName << "\n"
+           << "width:    " << vectorWidth << "\n"
+           << "pred:     " << hasPredicate << "\n"
+           << "argShapes:";
+    for (auto argShape : argShapes) errs() << ", " << argShape.str();
+    errs() << "\n";
+  }
+
   for (const auto & resolver : resolverServices) {
     std::unique_ptr<FunctionResolver> funcResolver = resolver->resolve(funcName, scaFuncTy, argShapes, vectorWidth, hasPredicate, mod);
     if (funcResolver) return funcResolver;

--- a/src/passes.cpp
+++ b/src/passes.cpp
@@ -39,6 +39,11 @@ addWholeFunctionVectorizer(llvm::legacy::PassManagerBase & PM) {
 }
 
 void
+addLowerBuiltinsPass(legacy::PassManagerBase & PM) {
+   PM.add(rv::createLowerRVIntrinsicsPass());
+}
+
+void
 addRVPasses(llvm::legacy::PassManagerBase & PM) {
   // normalize loops
   addPreparatoryPasses(PM);

--- a/src/transform/lowerRVIntrinsics.cpp
+++ b/src/transform/lowerRVIntrinsics.cpp
@@ -1,0 +1,37 @@
+//===- lowerRVIntrinsics.cpp - lower RV Builtins  ----------------===//
+//
+//                     The Region Vectorizer
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+//
+//
+//===----------------------------------------------------------------------===//
+
+#include "rv/transform/lowerRVIntrinsics.h"
+#include "rv/LinkAllPasses.h"
+
+#include "rv/rv.h"
+#include "report.h"
+#include <map>
+
+using namespace rv;
+using namespace llvm;
+
+// typedef DomTreeNodeBase<BasicBlock*> DomTreeNode;
+bool LowerRVIntrinsics::runOnFunction(Function &F) {
+  return rv::lowerIntrinsics(F);
+}
+
+void LowerRVIntrinsics::getAnalysisUsage(AnalysisUsage &AU) const { }
+
+char LowerRVIntrinsics::ID = 0;
+
+FunctionPass *rv::createLowerRVIntrinsicsPass() { return new LowerRVIntrinsics(); }
+
+INITIALIZE_PASS_BEGIN(LowerRVIntrinsics, "rv-lower-intrinsics",
+                      "RV - Lower intrinsics", false, false)
+INITIALIZE_PASS_END(LowerRVIntrinsics, "rv-lower-intrinsics", "RV - Lower Intrinsics",
+                    false, false)


### PR DESCRIPTION
This fixes the backend crash of rv_load/rv_store with imprecise varying shapes.
While this needs fixing in the backend, you'd want #37 to get proper code for this.