### PR TITLE
Use push_back() rather than [] operator to push to the array to avoid assert to fail in LLVM

### DIFF
--- a/src/transform/loopCloner.cpp
+++ b/src/transform/loopCloner.cpp
@@ -95,7 +95,7 @@ struct LoopCloner {
       SmallVector<BranchProbability, 2> Probs;
       Probs.reserve(term.getNumSuccessors());
       for (size_t i = 0; i < term.getNumSuccessors(); ++i) {
-        Probs[i] = PB->getEdgeProbability(block, i);
+        Probs.push_back(PB->getEdgeProbability(block, i));
       }
       PB->setEdgeProbability(cloned, Probs);
     }


### PR DESCRIPTION
Tested with LLVM 12.0 debug build and using [] operator without initializing memory causes following assert to happen in LLVM:
```
syrk.exe: /home/kazooie/extra/programming/llvm-project/llvm/include/llvm/ADT/SmallVector.h:183: T& llvm::SmallVectorTemplateCommon<T, <template-parameter-1-2> >::operator[](llvm::SmallVectorTemplateCommon<T, <template-parameter-1-2> >::size_type) [with T = llvm::BranchProbability; <template-parameter-1-2> = void; llvm::SmallVectorTemplateCommon<T, <template-parameter-1-2> >::reference = llvm::BranchProbability&; llvm::SmallVectorTemplateCommon<T, <template-parameter-1-2> >::size_type = long unsigned int]: Assertion `idx < size()' failed.
[1]    277026 abort (core dumped)  ./syrk.exe
```
And here is the LLVM implementation:
```cpp
  reference operator[](size_type idx) {
    assert(idx < size()); <---- this
    return begin()[idx];
  }
```
Correct way should be using push_back() or resize() before [] operator.