### PR TITLE
add include dir to CMake target

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -93,6 +93,8 @@ add_rv_library(RV
   ${RV_SLEEF_OBJECTS}
 )
 
+target_include_directories(RV PUBLIC ${RV_SOURCE_DIR}/include)
+
 if (BUILD_SHARED_LIBS)
   target_link_libraries(RV PUBLIC
     LLVMSupport


### PR DESCRIPTION
Adds the rv/include dir to the CMake target to allow for consumption of RV as part of normal LLVM CMake target import