### PR TITLE
Various Bugfixes.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,7 +112,7 @@ if (RV_REBUILD_GENBC AND LLVM_RVPLUG_LINK_INTO_TOOLS)
   message(FATAL_ERROR "Cannot set RV_REBUILD_GENBC and LLVM_RVPLUG_LINK_INTO_TOOLS at the same time. If you want to update the vecmath bitcode files and buffers, (temporarily) disable LLVM_RVPLUG_LINK_INTO_TOOLS, compile LLVM and copy the BUILD/tools/rv/lib/*.gen.cpp files to rv/vecmath/prebuilt_genbc/.")
 endif()
 
-OPTION(RV_ENABLE_VP "(experimental) Use LLVM-VP (Vector Predication) (https://reviews.llvm.org/D57504)." ON)
+OPTION(RV_ENABLE_VP "(experimental) Use LLVM-VP (Vector Predication) (https://reviews.llvm.org/D57504)." OFF)
 
 set(RV_TARGETS_TO_BUILD "Native" CACHE STRING "Semicolon-separated list of targets to build, or 'Native'.")
 string(REPLACE "Native" ${LLVM_NATIVE_ARCH} RV_TARGETS_TO_BUILD "${RV_TARGETS_TO_BUILD}")

--- a/src/native/NatBuilder.cpp
+++ b/src/native/NatBuilder.cpp
@@ -1754,7 +1754,8 @@ void NatBuilder::vectorizeMemoryInstruction(Instruction *const inst) {
   bool needsMask = predicate && !vecInfo.getVectorShape(*predicate).isUniform();
 
   // uniform loads from allocations do not need a mask!
-  if (needsMask && load && GetUnderlyingAlloca(accessedPtr)) {
+  auto alloca = GetUnderlyingAlloca(accessedPtr);
+  if (needsMask && load && alloca && vecInfo.getVectorShape(*alloca).isUniform()) {
     needsMask = false;
   }
 

--- a/src/native/NatBuilder.cpp
+++ b/src/native/NatBuilder.cpp
@@ -1562,7 +1562,9 @@ NatBuilder::vectorizeCallInstruction(CallInst *const scalCall) {
 
     auto & vecCall = createAnyGuard(needsGuardedCall, *scalCall->getParent(), *scalCall, producesValue,
       [&](IRBuilder<> & builder) {
-        return builder.CreateCall(&simdFunc, vectorArgs, callName);
+        auto *call = builder.CreateCall(&simdFunc, vectorArgs, callName);
+        call->setCallingConv(simdFunc.getCallingConv());
+        return call;
       });
 
     if (producesValue) { vecCall.setName(scalCall->getName() + ".mapped"); }
@@ -1605,6 +1607,7 @@ NatBuilder::vectorizeCallInstruction(CallInst *const scalCall) {
         CallInst *call = cast<CallInst>(scalCall->clone());
         call->mutateType(simdFunc.getReturnType());
         call->setCalledFunction(&simdFunc);
+        call->setCallingConv(simdFunc.getCallingConv());
 
         // insert arguments into call
         for (unsigned j = 0; j < scalCall->arg_size(); ++j) {

--- a/src/transform/srovTransform.cpp
+++ b/src/transform/srovTransform.cpp
@@ -482,10 +482,11 @@ size_t flattenedLoadStore(IRBuilder<> & builder, Value * ptr, ValVec & replVec, 
   if (ptrElemTy->isStructTy()) {
     auto * intTy = Type::getInt32Ty(builder.getContext());
     size_t n = ptrElemTy->getStructNumElements();
+
     for (size_t i = 0; i < n; i++) {
       // load every member
       auto *ElemTy = ptrElemTy->getStructElementType(i);
-      auto * elemGep = builder.CreateGEP(ElemTy, ptr, {ConstantInt::get(intTy, 0, true), ConstantInt::get(intTy, i, true)}, "srov_gep");
+      auto * elemGep = builder.CreateGEP(ptrElemTy, ptr, {ConstantInt::get(intTy, 0, true), ConstantInt::get(intTy, i, true)}, "srov_gep");
       vecInfo.setVectorShape(*elemGep, ptrShape); // FIXME alignment
       flatIdx = flattenedLoadStore(builder, elemGep, replVec, flatIdx, load, store);
     }

--- a/src/transform/structOpt.cpp
+++ b/src/transform/structOpt.cpp
@@ -228,7 +228,7 @@ StructOpt::transformLayout(llvm::AllocaInst & allocaInst, ValueToValueMapTy & tr
       auto ptrType = cast<PointerType>(vecBasePtr->getType()->getScalarType());
       Type * pointeeType = nullptr;
       if (!ptrType->isOpaque())
-          ptrType->getElementType();
+          pointeeType = ptrType->getElementType();
 
       auto * vecGep = GetElementPtrInst::Create(pointeeType, vecBasePtr, indexVec, gep->getName(), gep);
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -6,26 +6,33 @@ INCLUDE_DIRECTORIES ( include/ )
 
 ADD_EXECUTABLE ( ${RVTOOL_NAME} ${RVTOOL_SOURCE_FILES} )
 
+IF (LLVM_BUILD_LLVM_DYLIB AND LLVM_LINK_LLVM_DYLIB)
+  set(RV_TOOL_LIBS ${RV_LIBRARY_NAME})
+ELSE()
+  set(RV_TOOL_LIBS
+    ${RV_LIBRARY_NAME}
+    LLVMSupport
+    LLVMCore
+    LLVMScalarOpts
+    LLVMInstCombine
+    LLVMTransformUtils
+    LLVMAnalysis
+    LLVMipo
+    LLVMMC
+    LLVMIRReader
+    LLVMPasses
+  # The libraries below are required for darwin: http://PR26392
+    LLVMBitReader
+    LLVMMCParser
+    LLVMObject
+    LLVMProfileData
+    LLVMTarget
+    LLVMVectorize)
+ENDIF()
+
 # link with libRV in any case
 target_link_libraries(${RVTOOL_NAME}
-  ${RV_LIBRARY_NAME}
-  LLVMSupport
-  LLVMCore
-  LLVMScalarOpts
-  LLVMInstCombine
-  LLVMTransformUtils
-  LLVMAnalysis
-  LLVMipo
-  LLVMMC
-  LLVMIRReader
-  LLVMPasses
-# The libraries below are required for darwin: http://PR26392
-  LLVMBitReader
-  LLVMMCParser
-  LLVMObject
-  LLVMProfileData
-  LLVMTarget
-  LLVMVectorize
+  ${RV_TOOL_LIBS}
 )
 
 install (TARGETS ${RVTOOL_NAME} DESTINATION bin)


### PR DESCRIPTION
* Check alloca to be uniform before dropping masks for loads.
* <s>fastcc for sleef functions causes all sorts of havoc. Not sure why though.</s>
* srov_gep: Fix Element Type, has to be pointer element type instead of structelementtype.
* StructOp::transformLayout: actually set pointeeType.

I don't realy get why fastcc is a problem for sleef, but some tests fail if it is enabled. The results in these tests look as if parts of the code are skipped.  e.g.:
```
float foo (float t) { return fmod(fabs(t), 2); }

float bar (float t) { return fmod(fabs(t), 2) - 1; }
```
here, vectorized versions of foo and bar would produce the same results. The subtraction is somehow ignored.