### PR TITLE
LLVM 18 Support

### DIFF
--- a/include/rv/analysis/VectorizationAnalysis.h
+++ b/include/rv/analysis/VectorizationAnalysis.h
@@ -20,16 +20,18 @@
 #include "rv/vectorMapping.h"
 #include "rv/vectorizationInfo.h"
 
+#include "llvm/Analysis/CycleAnalysis.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SmallPtrSet.h"
-#include "llvm/Analysis/SyncDependenceAnalysis.h"
+#include "llvm/ADT/GenericUniformityImpl.h"
 #include "llvm/IR/BasicBlock.h"
 #include "llvm/IR/Dominators.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/InstVisitor.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/Operator.h"
+#include "llvm/IR/SSAContext.h"
 #include "llvm/IR/Use.h"
 #include "llvm/IR/Value.h"
 #include "llvm/Pass.h"
@@ -62,9 +64,10 @@ class VectorizationAnalysis {
   const llvm::DataLayout &layout;
   const llvm::LoopInfo &LI; // Preserves LoopInfo
   const llvm::DominatorTree &DT;
+  const llvm::CycleInfo &CI;
 
   // Divergence computation:
-  llvm::SyncDependenceAnalysis SDA;
+  llvm::GenericSyncDependenceAnalysis<llvm::SSAContext> SDA;
   PredicateAnalysis PredA;
 
   FunctionRegion funcRegion;

--- a/src/PlatformInfo.cpp
+++ b/src/PlatformInfo.cpp
@@ -18,7 +18,7 @@
 #include <llvm/IR/Module.h>
 #include <llvm/Support/raw_ostream.h>
 #include <llvm/Support/TypeSize.h>
-#include <llvm/ADT/Triple.h>
+#include <llvm/TargetParser/Triple.h>
 
 #include "rvConfig.h"
 

--- a/src/native/NatBuilder.cpp
+++ b/src/native/NatBuilder.cpp
@@ -1743,8 +1743,6 @@ void NatBuilder::vectorizeMemoryInstruction(Instruction *const inst) {
     accessedPtr = store->getPointerOperand();
   }
 
-  assert(cast<PointerType>(accessedPtr->getType())->isOpaqueOrPointeeTypeMatches(accessedType) &&
-         "accessed type and pointed object type differ!");
   assert(vecInfo.hasKnownShape(*accessedPtr) && "no shape for accessed pointer!");
   VectorShape addrShape = getVectorShape(*accessedPtr);
   Type *vecType = getVectorType(accessedType, vectorWidth());

--- a/src/shape/vectorShapeTransformer.cpp
+++ b/src/shape/vectorShapeTransformer.cpp
@@ -61,9 +61,7 @@ static Type* getElementType(Type* Ty) {
     return VecTy->getElementType();
   }
   if (auto PtrTy = dyn_cast<PointerType>(Ty)) {
-    if (PtrTy->isOpaque())
         return nullptr;
-    return PtrTy->getNonOpaquePointerElementType();
   }
   if (auto ArrTy = dyn_cast<ArrayType>(Ty)) {
     return ArrTy->getArrayElementType();


### PR DESCRIPTION
* Switch from SyncDependenceAnalysis to GenericSyncDependenceAnalysis
* llvm/ADT/Triple.h deprecated, changed to llvm/TargetParser/Triple.h